### PR TITLE
Fix file permissions on addon start

### DIFF
--- a/limited-guest-access/run.sh
+++ b/limited-guest-access/run.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/with-contenv bashio
 chmod 777 /data/
+mkdir -p /data/links
+chmod -R 666 /data/links
+chmod 777 /data/links
 chmod 644 /data/options.json
 is_ssl_active=$(cat /data/options.json |jq .activate_tls)
 if [ $is_ssl_active = true ]; then


### PR DESCRIPTION
I'm not sure how exactly it happened in my case, but somehow the add-on broke due to incorrect permissions. By broke I mean I was unable to create new URL or modify existing links. In logs I found messages about permissions like this one:
```
2023/07/22 12:48:39 [error] 96#96: *17 FastCGI sent in stderr: "PHP message: PHP Warning:  unlink(/data/links/a3e535.json): Permission denied in /var/www/admin/actions.php on line 161PHP message: PHP Fatal error:  Uncaught Exception: Unable to delete file in /var/www/admin/actions.php:164
```

I'm still not sure why it happened (some upgrade?), but this PR changes permissions on container start so similar issues would be automatically resolved with a reboot/addon restart.